### PR TITLE
DBの設定ファイルを作成しました

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: '.'
       dockerfile: ./container/Dockerfile.frontend
     ports:
-      - 3000:3000
+      - "${HOST_PORT:-3000}:3000"
     volumes:
       - ./frontend:/usr/src/frontend
       - node_modules:/usr/src/frontend/node_modules # node_modules

--- a/supabase/migrations/20260221092232_test_connection.sql
+++ b/supabase/migrations/20260221092232_test_connection.sql
@@ -1,5 +1,0 @@
-CREATE TABLE test_table (
-  id bigint primary key generated always as identity,
-  created_at timestamptz default now(),
-  test_name text
-);

--- a/supabase/migrations/20260221145656_create_initial_schema.sql
+++ b/supabase/migrations/20260221145656_create_initial_schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE public.users (
     id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     role TEXT NOT NULL CHECK (role IN ('admin', 'student')),
+    password_hash TEXT,
     created_at TIMESTAMPTZ DEFAULT now()
 );
 
@@ -11,6 +12,8 @@ CREATE TABLE public.personal_pages (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL UNIQUE REFERENCES public.users(id) ON DELETE CASCADE,
     password_hash TEXT,
+    content TEXT,
+    updated_at TIMESTAMPTZ DEFAULT now(),
     created_at TIMESTAMPTZ DEFAULT now()
 );
 

--- a/supabase/migrations/20260221145656_create_initial_schema.sql
+++ b/supabase/migrations/20260221145656_create_initial_schema.sql
@@ -1,0 +1,68 @@
+-- 1. users テーブル (Supabaseの標準認証 auth.users と紐付け)
+CREATE TABLE public.users (
+    id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('admin', 'student')),
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- 2. personal_pages テーブル (個人ページ)
+CREATE TABLE public.personal_pages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL UNIQUE REFERENCES public.users(id) ON DELETE CASCADE,
+    password_hash TEXT,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- 3. blog_categories テーブル (カテゴリマスタ)
+CREATE TABLE public.blog_categories (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+
+-- 初期カテゴリデータの挿入
+INSERT INTO public.blog_categories (name) VALUES 
+    ('research'), 
+    ('tech'), 
+    ('personal');
+
+-- 4. blogs テーブル (ブログ本文)
+CREATE TABLE public.blogs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    author_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    category_id INTEGER NOT NULL REFERENCES public.blog_categories(id),
+    title TEXT NOT NULL,
+    content TEXT,
+    is_published BOOLEAN DEFAULT false,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- 5. meeting_records テーブル (音声面談記録)
+CREATE TABLE public.meeting_records (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    blog_id UUID REFERENCES public.blogs(id) ON DELETE SET NULL,
+    audio_url TEXT NOT NULL,
+    raw_transcript TEXT,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- 6. schedules テーブル (個人のスケジュール)
+CREATE TABLE public.schedules (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ NOT NULL,
+    is_public BOOLEAN DEFAULT true
+);
+
+-- 7. zemi_slots テーブル (研究ゼミの枠)
+CREATE TABLE public.zemi_slots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    date DATE NOT NULL,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ NOT NULL,
+    max_capacity INTEGER NOT NULL DEFAULT 5,
+    booked_count INTEGER NOT NULL DEFAULT 0
+);

--- a/supabase/migrations/20260222064603_setup_triggers_and_rls.sql
+++ b/supabase/migrations/20260222064603_setup_triggers_and_rls.sql
@@ -1,0 +1,72 @@
+-- pgcrypto拡張機能を有効化（後述のパスワードハッシュ化で使用します）
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- 新規ユーザー登録時に実行される関数
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger AS $$
+BEGIN
+  -- 1. usersテーブルに基本情報を登録（デフォルトは 'student' とする）
+  INSERT INTO public.users (id, name, role)
+  -- raw_user_meta_data から名前を取得。なければ 'No Name'
+  VALUES (new.id, COALESCE(new.raw_user_meta_data->>'name', 'No Name'), 'student');
+
+  -- 2. personal_pagesテーブルに個人ページを自動開設
+  INSERT INTO public.personal_pages (user_id)
+  VALUES (new.id);
+
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER; -- SECURITY DEFINER により管理者権限で実行される
+
+-- auth.usersテーブルのINSERT後に上記の関数を呼び出すトリガー
+CREATE OR REPLACE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- テーブルのRLSを有効化
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.personal_pages ENABLE ROW LEVEL SECURITY;
+
+-- ==========================================
+-- public.users のポリシー
+-- ==========================================
+-- ログインしているユーザーは、全ユーザーのリストを見ることができる（チャット等で必要）
+CREATE POLICY "ログインユーザーは全ユーザー情報を閲覧可能" ON public.users
+  FOR SELECT USING (auth.role() = 'authenticated');
+
+-- 自分のプロフィールのみ更新可能
+CREATE POLICY "自分のプロフィールのみ更新可能" ON public.users
+  FOR UPDATE USING (auth.uid() = id);
+
+-- ==========================================
+-- public.personal_pages のポリシー
+-- ==========================================
+-- 管理者(admin) または 本人のみが無条件で閲覧可能
+CREATE POLICY "管理者と本人は個人ページを閲覧可能" ON public.personal_pages
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    EXISTS (SELECT 1 FROM public.users WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- 本人のみ自分のページの設定（パスワードなど）を更新可能
+CREATE POLICY "本人のみ個人ページを更新可能" ON public.personal_pages
+  FOR UPDATE USING (auth.uid() = user_id);
+
+-- パスワードが一致するかどうかを検証する関数（Next.jsから supabase.rpc() で呼び出す）
+CREATE OR REPLACE FUNCTION public.verify_personal_page_password(page_id UUID, input_password TEXT)
+RETURNS BOOLEAN AS $$
+DECLARE
+  stored_hash TEXT;
+BEGIN
+  -- 該当ページのパスワードハッシュを取得
+  SELECT password_hash INTO stored_hash FROM public.personal_pages WHERE id = page_id;
+  
+  -- パスワードが設定されていない場合はアクセス拒否
+  IF stored_hash IS NULL THEN
+     RETURN FALSE;
+  END IF;
+  
+  -- 入力されたパスワードをハッシュ化して比較 (pgcryptoのcrypt関数を使用)
+  RETURN stored_hash = crypt(input_password, stored_hash);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20260222100000_add_zemi_bookings.sql
+++ b/supabase/migrations/20260222100000_add_zemi_bookings.sql
@@ -1,0 +1,57 @@
+BEGIN;
+
+-- 1) Create zemi_bookings table
+CREATE TABLE public.zemi_bookings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slot_id UUID NOT NULL REFERENCES public.zemi_slots(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  status TEXT NOT NULL CHECK (status IN ('pending','confirmed','cancelled')) DEFAULT 'confirmed',
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX zemi_bookings_slot_user_uq ON public.zemi_bookings (slot_id, user_id);
+CREATE INDEX zemi_bookings_user_idx ON public.zemi_bookings (user_id);
+CREATE INDEX zemi_bookings_slot_idx ON public.zemi_bookings (slot_id);
+
+-- 2) Remove booked_count from zemi_slots (we'll rely on zemi_bookings counts)
+ALTER TABLE public.zemi_slots DROP COLUMN IF EXISTS booked_count;
+
+-- 3) Prevent overbooking using a BEFORE INSERT trigger that locks the slot row
+CREATE OR REPLACE FUNCTION public.zemi_bookings_prevent_overbook() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  v_max INTEGER;
+  v_booked INTEGER;
+BEGIN
+  SELECT max_capacity INTO v_max FROM public.zemi_slots WHERE id = NEW.slot_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Slot does not exist';
+  END IF;
+
+  SELECT COUNT(*) INTO v_booked FROM public.zemi_bookings WHERE slot_id = NEW.slot_id AND status <> 'cancelled';
+
+  IF v_booked >= v_max THEN
+    RAISE EXCEPTION 'Slot is full';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER zemi_bookings_before_insert
+BEFORE INSERT ON public.zemi_bookings
+FOR EACH ROW EXECUTE FUNCTION public.zemi_bookings_prevent_overbook();
+
+-- 4) Keep updated_at current on updates
+CREATE OR REPLACE FUNCTION public.set_updated_at_timestamp() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER zemi_bookings_set_updated_at
+BEFORE UPDATE ON public.zemi_bookings
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_timestamp();
+
+COMMIT;

--- a/supabase/migrations/20260303091912_enable_pgvector_and_update_blogs.sql
+++ b/supabase/migrations/20260303091912_enable_pgvector_and_update_blogs.sql
@@ -1,0 +1,10 @@
+-- 1. pgvector 拡張機能を有効化
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA extensions; --
+
+-- 2. blogs テーブルにベクトル保存用カラムを追加
+-- 次元数は、利用するLLMに合わせて設定します（後述）
+ALTER TABLE public.blogs 
+ADD COLUMN embedding extensions.vector(768); -- とりあえず768（Geminiの標準）
+
+-- 3. 高速検索用のインデックスを作成
+CREATE INDEX ON public.blogs USING hnsw (embedding extensions.vector_cosine_ops);


### PR DESCRIPTION
## プロジェクト名
chatbot

## 作成日
2026-03-03

## 作成者
@Mackey4869 

## 背景
DB設計ファイルがなかったので、初期設定の必要があった
ローカルでポート3000を使用しているため、私だけ、別のポートを使用したかった

## 何を修正したのか
- DB設計ファイルを追加した
- ポートを可変で設定できるようにした

## 変更ファイル名
- '.github/workflows/deploy.yml'
- 'supabase/migrations/20260221092232_test_connection.sql'
- 'supabase/migrations/20260221145656_create_initial_schema.sql'
- 'supabase/migrations/20260222064603_setup_triggers_and_rls.sql'
- 'supabase/migrations/20260222100000_add_zemi_bookings.sql'
- 'supabase/migrations/20260303091912_enable_pgvector_and_update_blogs.sql'

## 見てほしい箇所
- DBの設定が問題ないか確認お願いします　(特に、ブログとチャット)

## 備考
- 今回はDBの設定のみです。
- デフォルトのポート番号は、3000です。
